### PR TITLE
Exploration to make danger work with GitHub issue

### DIFF
--- a/source/platforms/GitHub.ts
+++ b/source/platforms/GitHub.ts
@@ -1,4 +1,5 @@
 import { GitHubPRDSL, GitHubDSL, GitHubAPIPR, GitHubJSONDSL } from "../dsl/GitHubDSL"
+import { debug } from "../debug"
 import { GitHubAPI } from "./github/GitHubAPI"
 import GitHubUtils from "./github/GitHubUtils"
 import gitDSLForGitHub from "./github/GitHubGit"
@@ -12,6 +13,8 @@ import { GitHubChecksCommenter } from "./github/comms/checksCommenter"
 /** Handles conforming to the Platform Interface for GitHub, API work is handle by GitHubAPI */
 
 export type GitHubType = Platform & { api: GitHubAPI }
+
+const d = debug("GitHub.ts")
 
 export function GitHub(api: GitHubAPI) {
   /**
@@ -39,6 +42,10 @@ export function GitHub(api: GitHubAPI) {
     getPlatformGitRepresentation: () => gitDSLForGitHub(api),
 
     getPlatformReviewDSLRepresentation: async () => {
+      // We should always be able to get the issue, regardless of whether we're dealing with a PR or just an issue
+      const issue = await getIssue()
+      d(`👋 issue = ${JSON.stringify(issue, null, 2)}`)
+
       let pr: GitHubPRDSL
       try {
         pr = await api.getPullRequestInfo()
@@ -51,7 +58,6 @@ export function GitHub(api: GitHubAPI) {
         `
       }
 
-      const issue = await getIssue()
       const commits = await api.getPullRequestCommits()
       const reviews = await api.getReviews()
       const requested_reviewers = await api.getReviewerRequests()

--- a/source/platforms/pullRequestParser.ts
+++ b/source/platforms/pullRequestParser.ts
@@ -43,6 +43,22 @@ export function pullRequestParser(address: string): PullRequestParts | null {
       }
     }
 
+    // Adding support for extracting the resource number from a GitHub issue
+    // URL means that when using the "pr" command, it can parse an issue, too.
+    //
+    // Now, I understand it might be confusing or inappropriate to feed an
+    // issue to the "pr" command, but it's handy while I'm poking around the
+    // system. This code doesn't have to make it into production anyways.
+    //
+    // shape: http://github.com/proj/repo/issue/1
+    if (includes(components.path, "issue")) {
+      return {
+        platform: GitHub.name,
+        repo: components.path.split("/issue")[0].slice(1),
+        pullRequestNumber: components.path.split("/issue/")[1],
+      }
+    }
+
     // shape: https://gitlab.com/GROUP[/SUBGROUP]/PROJ/merge_requests/123
     if (includes(components.path, "merge_requests")) {
       const regex = /\/(.+)\/merge_requests\/(\d+)/


### PR DESCRIPTION
This is just me messing around with the code to see if I understand how it works and whether there's a simple way to get Danger to extract enough information to run simple checks against GitHub issues, not just PRs.

The conversation started on https://github.com/danger/danger-js/issues/999.

 Being able to run with issues would be useful to bring Danger closer to [Peril](https://danger.systems/js/guides/peril.html). Danger via GitHub Actions sounds like a promising and easier to setup alternative to Peril, but right now it's only as useful when running on PRs, at least as far as I've been able to see in my experiments (see [this repo](https://github.com/mokagio/danger-github-actions-examples).

---

An **important note**. So far, I've only been using the `pr` command and the `ci` one with the `FAKE_CI`. Since my research is meant at working with GitHub Actions as the CI provider, the next step shall be to simulate that environment.

---

I've been testing these changes using these scripts:

```bash
#!/bin/bash

# This makes Danger CI run against an issue.
set -x

yarn build

DANGER_FAKE_CI='yep' \
  DEBUG='*' \
  DANGER_TEST_REPO='wordpress-mobile/WordPress-iOS' \
  DANGER_TEST_PR='13729' \
  node --inspect distribution/commands/danger-ci.js \
  --dangerfile ../../a8c/danger-settings/wordpress/ios.ts \
  --text-only
```

```bash
#!/bin/bash

# This runs against a PR, and can be used to make sure there's been no regression.
set -x

yarn build

DANGER_FAKE_CI='yep' \
  DEBUG='*' \
  DANGER_TEST_REPO='wordpress-mobile/WordPress-iOS' \
  DANGER_TEST_PR='14198' \
  node --inspect distribution/commands/danger-ci.js \
  --dangerfile ../../a8c/danger-settings/wordpress/ios.ts \
  --text-only
```